### PR TITLE
[x64] added support for libvmaf & updated theora patch url

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ ENV \
  LIBVA=2.6.0 \
  LIBVDPAU=1.2 \
  LIBVIDSTAB=1.1.0 \
+ LIBVMAF=master \
  NVCODEC=n9.1.23.1 \
  OGG=1.3.4 \
  OPENCOREAMR=0.1.5 \
@@ -45,6 +46,7 @@ RUN \
 	cmake \
 	curl \
 	diffutils \
+	doxygen \
 	g++ \
 	gcc \
 	git \
@@ -61,13 +63,19 @@ RUN \
 	libxml2-dev \
 	make \
 	nasm \
+	ninja-build \
 	perl \
 	pkg-config \
 	python \
+	python3 \
+	python3-pip\
+	python3-setuptools \
+	python3-wheel \
 	x11proto-xext-dev \
 	xserver-xorg-dev \
 	yasm \
-	zlib1g-dev 
+	zlib1g-dev && \
+        pip3 install meson
 
 # compile 3rd party libs
 RUN \
@@ -257,6 +265,19 @@ RUN \
  make && \
  make install
 RUN \
+ echo "**** grabbing vmaf ****" && \
+ mkdir -p /tmp/vmaf && \
+ git clone \
+        --branch ${LIBVMAF} \
+        https://github.com/Netflix/vmaf.git \
+        /tmp/vmaf
+RUN \
+ echo "**** compiling libvmaf ****" && \
+ cd /tmp/vmaf/libvmaf && \
+ meson build --buildtype release && \
+ ninja -vC build && \
+ ninja -vC build install
+RUN \
  echo "**** grabbing ogg ****" && \
  mkdir -p /tmp/ogg && \
  curl -Lf \
@@ -334,7 +355,7 @@ RUN \
 	/usr/share/automake-1.15/config.sub \
 	config.sub && \
  curl -fL \
-	'https://git.xiph.org/?p=theora.git;a=commitdiff_plain;h=7288b539c52e99168488dc3a343845c9365617c8' \
+	'https://gitlab.xiph.org/xiph/theora/-/commit/7288b539c52e99168488dc3a343845c9365617c8.diff' \
 	> png.patch && \
  patch ./examples/png2theora.c < png.patch && \
  ./configure \
@@ -470,6 +491,7 @@ RUN \
 	--enable-libtheora \
 	--enable-libv4l2 \
 	--enable-libvidstab \
+	--enable-libvmaf \
 	--enable-libvorbis \
 	--enable-libvpx \
 	--enable-libxml2 \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -264,7 +264,7 @@ RUN \
 	/usr/share/automake-1.15/config.sub \
 	config.sub && \
  curl -fL \
-	'https://git.xiph.org/?p=theora.git;a=commitdiff_plain;h=7288b539c52e99168488dc3a343845c9365617c8' \
+	'https://gitlab.xiph.org/xiph/theora/-/commit/7288b539c52e99168488dc3a343845c9365617c8.diff' \
 	> png.patch && \
  patch ./examples/png2theora.c < png.patch && \
  ./configure \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -265,7 +265,7 @@ RUN \
 	/usr/share/automake-1.15/config.sub \
 	config.sub && \
  curl -fL \
-	'https://git.xiph.org/?p=theora.git;a=commitdiff_plain;h=7288b539c52e99168488dc3a343845c9365617c8' \
+	'https://gitlab.xiph.org/xiph/theora/-/commit/7288b539c52e99168488dc3a343845c9365617c8.diff' \
 	> png.patch && \
  patch ./examples/png2theora.c < png.patch && \
  ./configure \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo in code or documentation in the README please file an issue and let us sort it out we do not need a PR  --> 
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

We welcome all PR’s though this doesn’t guarantee it will be accepted.

## Description: 
<!--- Describe your changes in detail -->
Added support for Netflix libvmaf on x86_64 (currently only available for x86_64) & fixed the patch url for theora

## Benefits of this PR and context: 
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->
This patch allows the usage of libvmaf as ffmpeg filter (and fixes an invalid url)

## How Has This Been Tested? 
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This patch was tested succesfully on x86_64 without any apparent problems

## Source / References:
https://github.com/Netflix/vmaf
<!--- Please include any forum posts/github links relevant to the PR -->
