### PR TITLE
Properly forward arguments including spaces

### DIFF
--- a/root/ffmpegwrapper.sh
+++ b/root/ffmpegwrapper.sh
@@ -13,12 +13,12 @@ set_uidgid () {
 run_ffmpeg () {
   # we do not have input file or it does not exist on disk just run as root
   if [ -z ${INPUT_FILE+x} ] || [ ! -f "${INPUT_FILE}" ]; then
-    /usr/local/bin/ffmpeg ${FULL_ARGS}
+    /usr/local/bin/ffmpeg "${FULL_ARGS}"
   # we found the input file run as abc
   else
     set_uidgid
     s6-setuidgid abc \
-      /usr/local/bin/ffmpeg ${FULL_ARGS}
+      /usr/local/bin/ffmpeg "${FULL_ARGS}"
   fi
   exit 0
 }


### PR DESCRIPTION
Fix for #3

<!--- Provide a general summary of your changes in the Title above -->

Properly forward the list of arguments in the bash script by wrapping the argument expansion with double quotes. This makes sure that if you provide "a b" (a single argument with a space in it) to the wrapper script it'll be forwarded as a single argument to ffmpeg (instead of two different arguments "a" and "b").

<!--- Before submitting a pull request please check the following -->


 - [X] I have read the [contributing](https://github.com/linuxserver/docker-ffmpeg/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications
