### PR TITLE
Handle input args containing spaces

### DIFF
--- a/root/ffmpegwrapper.sh
+++ b/root/ffmpegwrapper.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-FULL_ARGS=$@
+FULL_ARGS=( "$@" )
 
 set_uidgid () {
   # setup abc based on file perms
@@ -13,12 +13,12 @@ set_uidgid () {
 run_ffmpeg () {
   # we do not have input file or it does not exist on disk just run as root
   if [ -z ${INPUT_FILE+x} ] || [ ! -f "${INPUT_FILE}" ]; then
-    /usr/local/bin/ffmpeg ${FULL_ARGS}
+    /usr/local/bin/ffmpeg "${FULL_ARGS[@]}"
   # we found the input file run as abc
   else
     set_uidgid
     s6-setuidgid abc \
-      /usr/local/bin/ffmpeg ${FULL_ARGS}
+      /usr/local/bin/ffmpeg "${FULL_ARGS[@]}"
   fi
   exit 0
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-ffmpeg/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
<!--- Describe your changes in detail -->
Stores input args in an array and safely expand them to avoid unwanted word-splitting

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->
I wanted to used an shell function to run the docker image as a mostly drop-in replacement for ffmpeg:
```
ffmpeg() { docker run --rm -ti -v /mnt/freepool:/mnt/freepool -w $PWD linuxserver/ffmpeg "$@" }
```
With the understanding that $PWD would always be inside `/mnt/freepool`. I was hoping to be able to simply use tab completion for my files names and everything would behave as if ffmpeg was installed natively. Unfortunately I immediately found out that it didn't handle spaces. This PR completely remedies that issue.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested with multiple arguments and arguments with spaces, works as expected.

## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
I found this https://github.com/linuxserver/docker-ffmpeg/issues/3#issuecomment-867946302 after I had already created the same change independently. Felt like one of those "great minds" situations. :smile: 
