### PR TITLE
Bump to 6.0

### DIFF
--- a/.github/workflows/external_trigger.yml
+++ b/.github/workflows/external_trigger.yml
@@ -20,7 +20,7 @@ jobs:
           echo "**** External trigger running off of master branch. To disable this trigger, set a Github secret named \"PAUSE_EXTERNAL_TRIGGER_FFMPEG_MASTER\". ****"
           echo "External trigger running off of master branch. To disable this trigger, set a Github secret named \`PAUSE_EXTERNAL_TRIGGER_FFMPEG_MASTER\`" >> $GITHUB_STEP_SUMMARY
           echo "**** Retrieving external version ****"
-          EXT_RELEASE=$(echo 5.1.2-cli)
+          EXT_RELEASE=$(echo 6.0-cli)
           if [ -z "${EXT_RELEASE}" ] || [ "${EXT_RELEASE}" == "null" ]; then
             echo "**** Can't retrieve external version, exiting ****"
             FAILURE_REASON="Can't retrieve external version for ffmpeg branch master"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -103,7 +103,7 @@ pipeline {
       steps{
         script{
           env.EXT_RELEASE = sh(
-            script: ''' echo 5.1.2-cli ''',
+            script: ''' echo 6.0-cli ''',
             returnStdout: true).trim()
             env.RELEASE_LINK = 'custom_command'
         }

--- a/jenkins-vars.yml
+++ b/jenkins-vars.yml
@@ -3,7 +3,7 @@
 # jenkins variables
 project_name: docker-ffmpeg
 external_type: na
-custom_version_command: "echo 5.1.2-cli"
+custom_version_command: "echo 6.0-cli"
 release_type: stable
 release_tag: latest
 ls_branch: master

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -131,7 +131,7 @@ full_custom_readme: |
   Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64`.
 
   ## Versions
-
+  * **04.06.23:** - Bump to 6.0.
   * **14.12.22:** - Rebase to Jammy, bump to 5.1.2.
   * **19.06.22:** - Rebase to Focal.
   * **26.08.21:** - Add support for libOpenCL.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [X] I have read the [contributing](https://github.com/linuxserver/docker-ffmpeg/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
<!--- Describe your changes in detail -->
Bumps ffmpeg to the latest upstream release 6.0

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->
6.0 contains  "[...] many new encoders and decoders, filters, ffmpeg CLI tool improvements"
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Built and compiled on system, test converted sample mkv video.

```
# docker run --rm -it   -v $(pwd):/config  ffmpeg6.0   -i /config/sample_960x400_ocean_with_audio.mkv   -c:v libx264   -b:v 4M   -vf scale=1280:720   -c:a copy   /config/output.m                          kv
ffmpeg version 6.0 Copyright (c) 2000-2023 the FFmpeg developers
  built with gcc 11 (Ubuntu 11.3.0-1ubuntu1~22.04.1)
  configuration: --disable-debug --disable-doc --disable-ffplay --enable-ffprobe --enable-cuvid --enable-gpl --enable-libaom --enable-libass --enable-libfdk_aac --enable-libfreetype --enable-li                          bkvazaar --enable-libmp3lame --enable-libopencore-amrnb --enable-libopencore-amrwb --enable-libopenjpeg --enable-libopus --enable-libtheora --enable-libv4l2 --enable-libvidstab --enable-libvmaf                           --enable-libvorbis --enable-libvpx --enable-libxml2 --enable-libx264 --enable-libx265 --enable-libxvid --enable-nonfree --enable-nvdec --enable-nvenc --enable-opencl --enable-openssl --enable-                          small --enable-stripping --enable-vaapi --enable-vdpau --enable-version3
  libavutil      58.  2.100 / 58.  2.100
  libavcodec     60.  3.100 / 60.  3.100
  libavformat    60.  3.100 / 60.  3.100
  libavdevice    60.  1.100 / 60.  1.100
  libavfilter     9.  3.100 /  9.  3.100
  libswscale      7.  1.100 /  7.  1.100
  libswresample   4. 10.100 /  4. 10.100
  libpostproc    57.  1.100 / 57.  1.100
Input #0, matroska,webm, from '/config/sample_960x400_ocean_with_audio.mkv':
  Metadata:
    COMPATIBLE_BRANDS: isomavc1
    MAJOR_BRAND     : isom
    MINOR_VERSION   : 1
    ENCODER         : Lavf58.45.100
  Duration: 00:00:46.62, start: 0.000000, bitrate: 2976 kb/s
  Stream #0:0: Video: h264, yuv420p(progressive), 960x400 [SAR 1:1 DAR 12:5], 23.98 fps, 23.98 tbr, 1k tbn (default)
    Metadata:
      HANDLER_NAME    : GPAC ISO Video Handler
      ENCODER         : Lavc58.91.100 libx264
      DURATION        : 00:00:46.550000000
  Stream #0:1: Audio: vorbis, 48000 Hz, stereo, fltp (default)
    Metadata:
      HANDLER_NAME    : GPAC ISO Audio Handler
      ENCODER         : Lavc58.91.100 libvorbis
      DURATION        : 00:00:46.616000000
Stream mapping:
  Stream #0:0 -> #0:0 (h264 (native) -> h264 (libx264))
  Stream #0:1 -> #0:1 (copy)
Press [q] to stop, [?] for help
[libx264 @ 0x55bb9734bc00] using SAR=27/20
[libx264 @ 0x55bb9734bc00] using cpu capabilities: MMX2 SSE2Fast SSSE3 SSE4.1 Cache64
[libx264 @ 0x55bb9734bc00] profile High, level 3.1, 4:2:0, 8-bit
[libx264 @ 0x55bb9734bc00] 264 - core 164 - H.264/MPEG-4 AVC codec - Copyleft 2003-2023 - http://www.videolan.org/x264.html - options: cabac=1 ref=3 deblock=1:0:0 analyse=0x3:0x113 me=hex subme                          =7 psy=1 psy_rd=1.00:0.00 mixed_ref=1 me_range=16 chroma_me=1 trellis=1 8x8dct=1 cqm=0 deadzone=21,11 fast_pskip=1 chroma_qp_offset=-2 threads=12 lookahead_threads=2 sliced_threads=0 nr=0 decim                          ate=1 interlaced=0 bluray_compat=0 constrained_intra=0 bframes=3 b_pyramid=2 b_adapt=1 b_bias=0 direct=1 weightb=1 open_gop=0 weightp=2 keyint=250 keyint_min=23 scenecut=40 intra_refresh=0 rc_l                          ookahead=40 rc=abr mbtree=1 bitrate=4000 ratetol=1.0 qcomp=0.60 qpmin=0 qpmax=69 qpstep=4 ip_ratio=1.40 aq=1:1.00
Output #0, matroska, to '/config/output.mkv':
  Metadata:
    COMPATIBLE_BRANDS: isomavc1
    MAJOR_BRAND     : isom
    MINOR_VERSION   : 1
    encoder         : Lavf60.3.100
  Stream #0:0: Video: h264 (H264 / 0x34363248), yuv420p(tv, progressive), 1280x720 [SAR 27:20 DAR 12:5], q=2-31, 4000 kb/s, 23.98 fps, 1k tbn (default)
    Metadata:
      HANDLER_NAME    : GPAC ISO Video Handler
      DURATION        : 00:00:46.550000000
      encoder         : Lavc60.3.100 libx264
    Side data:
      cpb: bitrate max/min/avg: 0/0/4000000 buffer size: 0 vbv_delay: N/A
  Stream #0:1: Audio: vorbis (oV[0][0] / 0x566F), 48000 Hz, stereo, fltp (default)
    Metadata:
      HANDLER_NAME    : GPAC ISO Audio Handler
      ENCODER         : Lavc58.91.100 libvorbis
      DURATION        : 00:00:46.616000000
frame= 1116 fps= 38 q=-1.0 Lsize=   23230kB time=00:00:46.61 bitrate=4082.7kbits/s speed=1.58x
video:22671kB audio:531kB subtitle:0kB other streams:0kB global headers:4kB muxing overhead: 0.125233%
[libx264 @ 0x55bb9734bc00] frame I:22    Avg QP:20.89  size: 37052
[libx264 @ 0x55bb9734bc00] frame P:601   Avg QP:25.77  size: 23056
[libx264 @ 0x55bb9734bc00] frame B:493   Avg QP:25.16  size: 17327
[libx264 @ 0x55bb9734bc00] consecutive B-frames: 38.4%  6.3%  5.1% 50.2%
[libx264 @ 0x55bb9734bc00] mb I  I16..4: 24.9% 61.7% 13.3%
[libx264 @ 0x55bb9734bc00] mb P  I16..4: 12.2% 36.3%  5.6%  P16..4: 23.1%  6.7%  2.0%  0.0%  0.0%    skip:14.0%
[libx264 @ 0x55bb9734bc00] mb B  I16..4:  3.1%  7.3%  2.5%  B16..8: 29.8%  9.4%  2.1%  direct: 7.3%  skip:38.5%  L0:43.0% L1:44.3% BI:12.6%
[libx264 @ 0x55bb9734bc00] final ratefactor: 24.31
[libx264 @ 0x55bb9734bc00] 8x8 transform intra:65.2% inter:77.4%
[libx264 @ 0x55bb9734bc00] coded y,uvDC,uvAC intra: 49.0% 57.4% 20.6% inter: 22.3% 24.9% 3.5%
[libx264 @ 0x55bb9734bc00] i16 v,h,dc,p: 36% 33%  7% 24%
[libx264 @ 0x55bb9734bc00] i8 v,h,dc,ddl,ddr,vr,hd,vl,hu: 19% 22% 18%  5%  7%  6%  8%  6%  8%
[libx264 @ 0x55bb9734bc00] i4 v,h,dc,ddl,ddr,vr,hd,vl,hu: 23% 23% 14%  5%  9%  8%  8%  5%  5%
[libx264 @ 0x55bb9734bc00] i8c dc,h,v,p: 57% 21% 17%  6%
[libx264 @ 0x55bb9734bc00] Weighted P-Frames: Y:7.8% UV:6.5%
[libx264 @ 0x55bb9734bc00] ref P L0: 65.9% 13.9% 13.7%  6.4%  0.1%
[libx264 @ 0x55bb9734bc00] ref B L0: 92.6%  5.7%  1.8%
[libx264 @ 0x55bb9734bc00] ref B L1: 97.6%  2.4%
[libx264 @ 0x55bb9734bc00] kb/s:3989.82
```

## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
Resolves #28, Blocked By #30