### PR TITLE
Adds SVT-AV1 encoder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -169,7 +169,7 @@ RUN \
   ./configure \
     --disable-static \
     --enable-shared && \
-   make && \
+  make && \
   make install 
 RUN \
   echo "**** grabbing fribidi ****" && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -617,7 +617,7 @@ RUN \
 RUN \
   echo "**** compiling ffmpeg ****" && \
   cd /tmp/ffmpeg && \
-  ./configure \
+    ./configure \
     --disable-debug \
     --disable-doc \
     --disable-ffplay \

--- a/Dockerfile
+++ b/Dockerfile
@@ -471,7 +471,11 @@ RUN \
     svtav1_build && \
   cd svtav1_build && \
   cmake \
-    -DCMAKE_BUILD_TYPE=Release .. && \
+    -DCMAKE_BUILD_TYPE=Release .. \
+    -DCBUILD_SHARED_LIBS=OFF \
+    -DBUILD_DEC=OFF \
+    -DSV_AV1_LTO=ON \
+    -DNATIVE=ON && \
   make && \
   make install
 RUN \

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,7 @@ ENV \
   OPENCOREAMR=0.1.6 \
   OPENJPEG=2.5.0 \
   OPUS=1.3.1 \
+  SVTAV1=v1.7.0 \
   THEORA=1.1.1 \
   VORBIS=1.3.7 \
   VPX=1.13.0 \
@@ -168,7 +169,7 @@ RUN \
   ./configure \
     --disable-static \
     --enable-shared && \
-  make && \
+   make && \
   make install 
 RUN \
   echo "**** grabbing fribidi ****" && \
@@ -454,6 +455,26 @@ RUN \
   make && \
   make install
 RUN \
+  echo "**** grabbing SVT-AV1 ****" && \
+  mkdir -p /tmp/svtav1 /usr/local/svtav1 && \
+  git clone \
+    --branch ${SVTAV1} \
+    --depth 1 https://gitlab.com/AOMediaCodec/SVT-AV1.git \
+    /tmp/svtav1
+RUN \
+  echo "**** compiling SVT-AV1 ****" && \
+  cd /tmp/svtav1 && \
+  rm -rf \
+    CMakeCache.txt \
+    CMakeFiles && \
+  mkdir -p \
+    svtav1_build && \
+  cd svtav1_build && \
+  cmake \
+    -DCMAKE_BUILD_TYPE=Release .. && \
+  make && \
+  make install
+RUN \
   echo "**** grabbing theora ****" && \
   mkdir -p /tmp/theora && \
   curl -Lf \
@@ -596,7 +617,7 @@ RUN \
 RUN \
   echo "**** compiling ffmpeg ****" && \
   cd /tmp/ffmpeg && \
-    ./configure \
+  ./configure \
     --disable-debug \
     --disable-doc \
     --disable-ffplay \
@@ -632,6 +653,7 @@ RUN \
     --enable-openssl \
     --enable-small \
     --enable-stripping \
+    --enable-libsvtav1 \
     --enable-vaapi \
     --enable-vdpau \
     --enable-version3 && \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -30,6 +30,7 @@ ENV \
   OPENCOREAMR=0.1.6 \
   OPENJPEG=2.5.0 \
   OPUS=1.3.1 \
+  SVTAV1=v1.7.0 \
   THEORA=1.1.1 \
   VORBIS=1.3.7 \
   VPX=1.13.0 \
@@ -260,6 +261,30 @@ RUN \
   make && \
   make install
 RUN \
+  echo "**** grabbing SVT-AV1 ****" && \
+  mkdir -p /tmp/svtav1 /usr/local/svtav1 && \
+  git clone \
+    --branch ${SVTAV1} \
+    --depth 1 https://gitlab.com/AOMediaCodec/SVT-AV1.git \
+    /tmp/svtav1
+RUN \
+  echo "**** compiling SVT-AV1 ****" && \
+  cd /tmp/svtav1 && \
+  rm -rf \
+    CMakeCache.txt \
+    CMakeFiles && \
+  mkdir -p \
+    svtav1_build && \
+  cd svtav1_build && \
+  cmake \
+    -DCMAKE_BUILD_TYPE=Release .. \
+    -DCBUILD_SHARED_LIBS=OFF \
+    -DBUILD_DEC=OFF \
+    -DSV_AV1_LTO=ON \
+    -DNATIVE=ON && \
+  make && \
+  make install
+RUN \
   echo "**** grabbing theora ****" && \
   mkdir -p /tmp/theora && \
   curl -Lf \
@@ -435,6 +460,7 @@ RUN \
     --enable-openssl \
     --enable-small \
     --enable-stripping \
+    --enable-libsvtav1 \
     --enable-version3 && \
   make
 

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -1,5 +1,4 @@
 ---
-
 # project information
 project_name: ffmpeg
 full_custom_readme: |
@@ -12,15 +11,15 @@ full_custom_readme: |
   [![Fleet](https://img.shields.io/static/v1.svg?color=94398d&labelColor=555555&logoColor=ffffff&style=for-the-badge&label=linuxserver.io&message=Fleet)](https://fleet.linuxserver.io "an online web interface which displays all of our maintained images.")
   [![GitHub](https://img.shields.io/static/v1.svg?color=94398d&labelColor=555555&logoColor=ffffff&style=for-the-badge&label=linuxserver.io&message=GitHub&logo=github)](https://github.com/linuxserver "view the source for all of our repositories.")
   [![Open Collective](https://img.shields.io/opencollective/all/linuxserver.svg?color=94398d&labelColor=555555&logoColor=ffffff&style=for-the-badge&label=Supporters&logo=open%20collective)](https://opencollective.com/linuxserver "please consider helping us by either donating or contributing to our budget")
-  
+
   The [LinuxServer.io](https://linuxserver.io) team brings you another container release featuring :-
-  
+
    * regular and timely application updates
    * easy user mappings (PGID, PUID)
    * custom base image with s6 overlay
    * weekly base OS updates with common layers across the entire LinuxServer.io ecosystem to minimise space usage, down time and bandwidth
    * regular security updates
-  
+
   Find us at:
   * [Blog](https://blog.linuxserver.io) - all the things you can do with our containers including How-To guides, opinions and much more!
   * [Discord](https://discord.gg/YWrKVTn) - realtime support / chat with the community and the team.
@@ -37,12 +36,12 @@ full_custom_readme: |
   [![Docker Pulls](https://img.shields.io/docker/pulls/linuxserver/ffmpeg.svg?color=94398d&labelColor=555555&logoColor=ffffff&style=for-the-badge&label=pulls&logo=docker)](https://hub.docker.com/r/linuxserver/ffmpeg)
   [![Docker Stars](https://img.shields.io/docker/stars/linuxserver/ffmpeg.svg?color=94398d&labelColor=555555&logoColor=ffffff&style=for-the-badge&label=stars&logo=docker)](https://hub.docker.com/r/linuxserver/ffmpeg)
   [![Jenkins Build](https://img.shields.io/jenkins/build?labelColor=555555&logoColor=ffffff&style=for-the-badge&jobUrl=https%3A%2F%2Fci.linuxserver.io%2Fjob%2FDocker-Pipeline-Builders%2Fjob%2Fdocker-ffmpeg%2Fjob%2Fmaster%2F&logo=jenkins)](https://ci.linuxserver.io/job/Docker-Pipeline-Builders/job/docker-ffmpeg/job/master/)
-  
+
   [FFmpeg](https://ffmpeg.org) - A complete, cross-platform solution to record, convert and stream audio and video.
-  
-  
+
+
   [![ffmpeg](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/ffmpeg.png)](https://ffmpeg.org)
-  
+
   ## Supported Architectures
 
   We utilise the docker manifest for multi-platform awareness. More information is available from docker [here](https://github.com/docker/distribution/blob/master/docs/spec/manifest-v2-2.md#manifest-list) and our announcement [here](https://blog.linuxserver.io/2019/02/21/the-lsio-pipeline-project/).
@@ -56,9 +55,9 @@ full_custom_readme: |
   | x86-64 | ✅ | amd64-\<version tag\> |
   | arm64 | ✅ | arm64v8-\<version tag\> |
   | armhf| ❌ | arm32v7-\<version tag\> |
-  
+
   ## Usage
-  
+
   Unlike most of our container library this image is meant to be run ephemerally from the command line parsing user input for a custom FFmpeg command. You will need to understand some Docker basics to use this image and be familiar with how to construct an FFmpeg command. In the commands below we will be bind mounting our current working directory from the CLI to /config, the assumption is that input.mkv is in your current working directory.
 
   If an input file is detected we will run FFmpeg as that user/group so the output file will match its permissions.
@@ -88,7 +87,7 @@ full_custom_readme: |
   ```
 
   ### Hardware accelerated (VAAPI) ([click for more info](https://trac.ffmpeg.org/wiki/Hardware/VAAPI))
-  
+
   ```
   docker run --rm -it \
     --device=/dev/dri:/dev/dri \
@@ -104,7 +103,7 @@ full_custom_readme: |
   ```
 
   ### Hardware accelerated (QSV) ([click for more info](https://trac.ffmpeg.org/wiki/Hardware/QuickSync))
-  
+
   ```
   docker run --rm -it \
     --device=/dev/dri:/dev/dri \
@@ -135,7 +134,7 @@ full_custom_readme: |
   ```
 
   ## Building locally
-  
+
   If you want to make local modifications to these images for development purposes or just to customize the logic:
   ```
   git clone https://github.com/linuxserver/docker-ffmpeg.git
@@ -145,7 +144,7 @@ full_custom_readme: |
     --pull \
     -t linuxserver/ffmpeg:latest .
   ```
-  
+
   The ARM variants can be built on x86_64 hardware using `multiarch/qemu-user-static`
   ```
   docker run --rm --privileged multiarch/qemu-user-static:register --reset
@@ -155,6 +154,7 @@ full_custom_readme: |
 
   ## Versions
 
+  * **06.10.23:** - Added support for SVT-AV1.
   * **16.08.23:** - Added support for WebP formats.
   * **11.08.23:** - Add optional i965 driver for gen5+ support.
   * **14.06.23:** - Switch to latest iHD for Intel, add qsv support.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-ffmpeg/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
Adds the SVT-AV1 encoder for production-level AV1 encoding.

## Benefits of this PR and context:
The AOM AV1 encoder is slow and not really practical for production use. SVT-AV1 is defacto standard encoder for AV1 right now and this enhancement will improve the viability of this docker image as the video industry progresses.

## How Has This Been Tested?
I ran the docker build process on an Intel-based Macbook Pro and then transcoded a 30-second 4K clip from h.265 to AV1 using the SVT-AV1 encoder. I then reviewed the resulting file on the mac using VLC media player and confirmed playback was smooth and the video looked as good as the source. I then reviewed the Media Information in VLC and confirmed the correct codec was in use. I then placed the file into my Plex Media Server and confirmed playback on my FireTV Omni (2 different TVs). My TVs support direct play of AV1 -- Plex dash confirmed Direct Play (so the TV was decoding natively with no assistance from Plex) and playback on the TV was smooth.

I then repeated the above process on an M1-based mac to confirm the aarch64 Dockerfile and the transcoding process work the same. I had the same results as above.

This change, while important, simply instructs the Docker build process to download and compile SVT-AV1 from its repo on gitlab (https://gitlab.com/AOMediaCodec/SVT-AV1.git) and then enable it during the ffmpeg compile process


## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->

https://gitlab.com/AOMediaCodec/SVT-AV1.git
https://gitlab.com/AOMediaCodec/SVT-AV1/-/blob/master/Docs/Ffmpeg.md
https://gist.github.com/mrintrepide/b3009f5d0f08d437ebbb4c17cbf36e18
