### PR TITLE
Remove `--enable-small` from ffmpeg build options

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -644,7 +644,6 @@ RUN \
     --enable-nvenc \
     --enable-opencl \
     --enable-openssl \
-    --enable-small \
     --enable-stripping \
     --enable-vaapi \
     --enable-vdpau \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -447,7 +447,6 @@ RUN \
     --enable-libwebp \
     --enable-nonfree \
     --enable-openssl \
-    --enable-small \
     --enable-stripping \
     --enable-version3 && \
   make

--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **02.11.23:** - Remove `--enable-small` from ffmpeg build options to add back some features.
 * **05.10.23:** - Add support for SVT-AV1. Update various libraries.
 * **16.08.23:** - Added support for WebP formats.
 * **11.08.23:** - Add optional i965 driver for gen5+ support.

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -155,6 +155,7 @@ full_custom_readme: |
 
   ## Versions
 
+  * **02.11.23:** - Remove `--enable-small` from ffmpeg build options to add back some features.
   * **05.10.23:** - Add support for SVT-AV1. Update various libraries.
   * **16.08.23:** - Added support for WebP formats.
   * **11.08.23:** - Add optional i965 driver for gen5+ support.


### PR DESCRIPTION
Binaries get a little bit larger but not significantly

closes #43 