### PR TITLE
Set makeflags jobs to number of CPUs detected on host

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ARG FFMPEG_VERSION
 # common env
 ENV \
   DEBIAN_FRONTEND="noninteractive" \
-  MAKEFLAGS="-j4"
+  MAKEFLAGS="-j$(nproc)"
 
 # versions
 ENV \


### PR DESCRIPTION
## Description:
This patch sets makeflags jobs to number of CPUs detected on host via `nproc`.

## Benefits of this PR and context:
This patch sets the makeflags variable to the automatically detected number of logical CPUs on the host via `nproc`, instead of hard-coding the number to 4. This should speed up the build times significantly on modern multi-processor hosts. 