### PR TITLE
Correct the upstream URL for libva

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -274,7 +274,7 @@ RUN \
   echo "**** grabbing libva ****" && \
   mkdir -p /tmp/libva && \
   curl -Lf \
-    https://github.com/intel/libva/archive/${LIBVA}.tar.gz | \
+    https://github.com/intel/libva/archive/refs/tags/${LIBVA}.tar.gz | \
     tar -zx --strip-components=1 -C /tmp/libva
 RUN \
   echo "**** compiling libva ****" && \


### PR DESCRIPTION
Libva is fetched from the release tarballs, whose URL has changed. Update this to point to the correct URL pattern upstream.