### PR TITLE
Enable the full stack of CUDA-related filters via `----enable-cuda-llvm`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,6 +59,11 @@ RUN \
     automake \
     bzip2 \
     cmake \
+    clang \
+    clang-tools \
+    libclang1 \
+    clang-format \
+    clangd \
     diffutils \
     doxygen \
     g++ \
@@ -76,6 +81,13 @@ RUN \
     libtool \
     libv4l-dev \
     libwayland-dev \
+    libllvm-ocaml-dev \
+    libllvm12 \
+    llvm \
+    llvm-dev \
+    llvm-runtime \
+    lldb \
+    lld \
     libx11-dev \
     libx11-xcb-dev \
     libxcb-dri3-dev \
@@ -763,6 +775,7 @@ RUN \
     --enable-nonfree \
     --enable-nvdec \
     --enable-nvenc \
+    --enable-cuda-llvm \
     --enable-opencl \
     --enable-openssl \
     --enable-stripping \

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,10 +60,6 @@ RUN \
     bzip2 \
     cmake \
     clang \
-    clang-tools \
-    libclang1 \
-    clang-format \
-    clangd \
     diffutils \
     doxygen \
     g++ \
@@ -81,13 +77,6 @@ RUN \
     libtool \
     libv4l-dev \
     libwayland-dev \
-    libllvm-ocaml-dev \
-    libllvm12 \
-    llvm \
-    llvm-dev \
-    llvm-runtime \
-    lldb \
-    lld \
     libx11-dev \
     libx11-xcb-dev \
     libxcb-dri3-dev \
@@ -787,6 +776,7 @@ RUN \
 
 RUN \
   echo "**** arrange files ****" && \
+  /usr/local/lib/rustlib/uninstall.sh && 
   ldconfig && \
   mkdir -p \
     /buildout/usr/local/bin \

--- a/Dockerfile
+++ b/Dockerfile
@@ -776,7 +776,7 @@ RUN \
 
 RUN \
   echo "**** arrange files ****" && \
-  /usr/local/lib/rustlib/uninstall.sh && 
+  /usr/local/lib/rustlib/uninstall.sh && \
   ldconfig && \
   mkdir -p \
     /buildout/usr/local/bin \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -476,7 +476,7 @@ RUN \
 
 RUN \
   echo "**** arrange files ****" && \
-  /usr/local/lib/rustlib/uninstall.sh && 
+  /usr/local/lib/rustlib/uninstall.sh && \
   ldconfig && \
   mkdir -p \
     /buildout/usr/local/bin \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -476,6 +476,7 @@ RUN \
 
 RUN \
   echo "**** arrange files ****" && \
+  /usr/local/lib/rustlib/uninstall.sh && 
   ldconfig && \
   mkdir -p \
     /buildout/usr/local/bin \

--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **08.02.24:** - Enable cuda-llvm, clean up rustc.
 * **01.02.24:** - Bump Mesa to v24.
 * **21.01.24:** - Add alsa support.
 * **18.01.24:** - Let the wrapper pass the ffmpeg exit code to docker run. Bump various libs.

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -177,6 +177,7 @@ full_custom_readme: |
 
   ## Versions
 
+  * **08.02.24:** - Enable cuda-llvm, clean up rustc.
   * **01.02.24:** - Bump Mesa to v24.
   * **21.01.24:** - Add alsa support.
   * **18.01.24:** - Let the wrapper pass the ffmpeg exit code to docker run. Bump various libs.


### PR DESCRIPTION
As at the moment, this FFmpeg build's filtering capabilities are extremely limited in NVENC-based workloads, lacking multiple CUDA-based filters needed for a fully functional GPU-bound transcode.

This patch adds the `--enable-cuda-llvm` `./configure` parameter to FFmpeg's builds, with the addition of clang as build requirements for these extra filters.

The following filters are now additionally available, and without invoking the installation of the proprietary NVIDIA CUDA SDK: 

```sh
ffmpeg -filters | grep cuda
 ... bilateral_cuda    V->V       (null)
 T.. bwdif_cuda        V->V       (null)
 ... chromakey_cuda    V->V       (null)
 ... colorspace_cuda   V->V       (null)
 ... hwupload_cuda     V->V       (null)
 ... overlay_cuda      VV->V      (null)
 ... scale_cuda        V->V       (null)
 ... thumbnail_cuda    V->V       (null)
 T.. yadif_cuda        V->V       (null)
``` 

Licensing, therefore, remains unaffected.

