### PR TITLE
Bumps SVTAV1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ ENV \
   OPUS=1.5.2 \
   RAV1E=0.7.1 \
   SHADERC=v2024.1 \
-  SVTAV1=2.0.0 \
+  SVTAV1=2.1.0 \
   THEORA=1.1.1 \
   VORBIS=1.3.7 \
   VPLGPURT=24.1.5 \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -34,7 +34,7 @@ ENV \
   OPENJPEG=2.5.2 \
   OPUS=1.5.2 \
   RAV1E=0.7.1 \
-  SVTAV1=2.0.0 \
+  SVTAV1=2.1.0 \
   THEORA=1.1.1 \
   VORBIS=1.3.7 \
   VPX=1.14.0 \

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ docker run --rm --privileged multiarch/qemu-user-static:register --reset
 Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64`.
 
 ## Versions
-
+* **20.05.24:** - Bump libsvtav1.
 * **09.05.24:** - Bump libaom, fribidi, kvazaar, various Intel drivers and libs, Mesa, opus, shaderc, webp and x265.
 * **11.04.24:** - Explicitly disable libdrm on aarch64, add new lib `libxcb-shm0`. Add quick test at the end of build.
 * **10.04.24:** - Compile ffmpeg with `libfribidi`, `libharfbuzz` and `libfontconfig`, compile libharfbuzz.


### PR DESCRIPTION
Bumps SVTAV1 to 2.1.0

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [ ] I have read the [contributing](https://github.com/linuxserver/docker-ffmpeg/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
Bumped SVT-AV1 to v2.1.0 now that it's released

## Benefits of this PR and context:
Moves a rapidly developing encoder to its latest stable release

## How Has This Been Tested?
I ran the generated image from this PR locally and transcoded an AVC1 MP4 to AV1 MKV and all is good.


## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
