### PR TITLE
Added support for SRT and RIST streaming protocols

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,8 +47,8 @@ ENV \
   RAV1E=0.7.1 \
   RIST=0.2.10 \
   SHADERC=v2024.1 \
-  SVTAV1=2.1.2 \
   SRT=1.5.3 \
+  SVTAV1=2.1.2 \
   THEORA=1.1.1 \
   VORBIS=1.3.7 \
   VPLGPURT=24.2.5 \
@@ -619,6 +619,40 @@ RUN \
   meson build --buildtype release && \
   ninja -C build install
 RUN \
+  echo "**** grabbing rist ****" && \
+  mkdir -p /tmp/rist && \
+  git clone \
+    --branch v${RIST} \
+    --depth 1 https://code.videolan.org/rist/librist.git \
+    /tmp/rist
+RUN \
+  echo "**** compiling rist ****" && \
+  cd /tmp/rist && \
+  mkdir -p \
+    rist_build && \
+  cd rist_build && \
+  meson \
+    --default-library=shared .. && \
+  ninja && \
+  ninja install
+RUN \
+  echo "**** grabbing srt ****" && \
+  mkdir -p /tmp/srt && \
+  git clone \
+    --branch v${SRT} \
+    --depth 1 https://github.com/Haivision/srt.git \
+    /tmp/srt
+RUN \
+  echo "**** compiling srt ****" && \
+  cd /tmp/srt && \
+  mkdir -p \
+    srt_build && \
+  cd srt_build && \
+  cmake \
+    -DBUILD_SHARED_LIBS:BOOL=on .. && \
+  make && \
+  make install
+RUN \
   echo "**** grabbing SVT-AV1 ****" && \
   mkdir -p /tmp/svt-av1 && \
   curl -Lf \
@@ -804,43 +838,6 @@ RUN \
   make && \
   make install
 
-RUN \
-  echo "**** grabbing srt ****" && \
-  mkdir -p /tmp/srt && \
-  git clone \
-    --branch v${SRT} \
-    --depth 1 https://github.com/Haivision/srt.git \
-    /tmp/srt
-RUN \
-  echo "**** compiling srt ****" && \
-  cd /tmp/srt && \
-  mkdir -p \
-    srt_build && \
-  cd srt_build && \
-  cmake \
-    -DBUILD_SHARED_LIBS:BOOL=on .. && \
-  make && \
-  make install
-
-RUN \
-  echo "**** grabbing rist ****" && \
-  mkdir -p /tmp/rist && \
-  git clone \
-    --branch v${RIST} \
-    --depth 1 https://code.videolan.org/rist/librist.git \
-    /tmp/rist
-RUN \
-  echo "**** compiling rist ****" && \
-  cd /tmp/rist && \
-  mkdir -p \
-    rist_build && \
-  cd rist_build && \
-  meson \
-    --default-library=shared .. && \
-  ninja && \
-  ninja install
-
-
 # main ffmpeg build
 RUN \
   echo "**** Versioning ****" && \
@@ -882,7 +879,9 @@ RUN \
     --enable-libopus \
     --enable-libplacebo \
     --enable-librav1e \
+    --enable-librist \
     --enable-libshaderc \
+    --enable-libsrt \
     --enable-libsvtav1 \
     --enable-libtheora \
     --enable-libv4l2 \
@@ -897,8 +896,6 @@ RUN \
     --enable-libxml2 \
     --enable-libxvid \
     --enable-libzimg \
-    --enable-librist \
-    --enable-libsrt \
     --enable-nonfree \
     --enable-nvdec \
     --enable-nvenc \
@@ -1032,3 +1029,4 @@ RUN \
 COPY /root /
 
 ENTRYPOINT ["/ffmpegwrapper.sh"]
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,7 @@ ENV \
   RAV1E=0.7.1 \
   SHADERC=v2024.1 \
   SVTAV1=2.1.2 \
+  SRT=1.5.3 \
   THEORA=1.1.1 \
   VORBIS=1.3.7 \
   VPLGPURT=24.2.5 \
@@ -802,6 +803,24 @@ RUN \
   make && \
   make install
 
+RUN \
+  echo "**** grabbing srt ****" && \
+  mkdir -p /tmp/srt && \
+  git clone \
+    --branch v${SRT} \
+    --depth 1 https://github.com/Haivision/srt.git \
+    /tmp/srt
+RUN \
+  echo "**** compiling srt ****" && \
+  cd /tmp/srt && \
+  mkdir -p \
+    srt_build && \
+  cd srt_build && \
+  cmake \
+    -DBUILD_SHARED_LIBS:BOOL=on .. && \
+  make && \
+  make install
+
 # main ffmpeg build
 RUN \
   echo "**** Versioning ****" && \
@@ -858,6 +877,7 @@ RUN \
     --enable-libxml2 \
     --enable-libxvid \
     --enable-libzimg \
+    --enable-libsrt \
     --enable-nonfree \
     --enable-nvdec \
     --enable-nvenc \

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,7 @@ ENV \
   OPENJPEG=2.5.2 \
   OPUS=1.5.2 \
   RAV1E=0.7.1 \
+  RIST=0.2.10 \
   SHADERC=v2024.1 \
   SVTAV1=2.1.2 \
   SRT=1.5.3 \
@@ -821,6 +822,25 @@ RUN \
   make && \
   make install
 
+RUN \
+  echo "**** grabbing rist ****" && \
+  mkdir -p /tmp/rist && \
+  git clone \
+    --branch v${RIST} \
+    --depth 1 https://code.videolan.org/rist/librist.git \
+    /tmp/rist
+RUN \
+  echo "**** compiling rist ****" && \
+  cd /tmp/rist && \
+  mkdir -p \
+    rist_build && \
+  cd rist_build && \
+  meson \
+    --default-library=shared .. && \
+  ninja && \
+  ninja install
+
+
 # main ffmpeg build
 RUN \
   echo "**** Versioning ****" && \
@@ -877,6 +897,7 @@ RUN \
     --enable-libxml2 \
     --enable-libxvid \
     --enable-libzimg \
+    --enable-librist \
     --enable-libsrt \
     --enable-nonfree \
     --enable-nvdec \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -36,6 +36,8 @@ ENV \
   OPENJPEG=2.5.2 \
   OPUS=1.5.2 \
   RAV1E=0.7.1 \
+  RIST=0.2.10 \
+  SRT=1.5.3 \  
   SVTAV1=2.1.2 \
   THEORA=1.1.1 \
   VORBIS=1.3.7 \
@@ -340,6 +342,40 @@ RUN \
     https://gitlab.com/AOMediaCodec/SVT-AV1/-/archive/v${SVTAV1}/SVT-AV1-v${SVTAV1}.tar.gz | \
     tar -zx --strip-components=1 -C /tmp/svt-av1
 RUN \
+  echo "**** grabbing rist ****" && \
+  mkdir -p /tmp/rist && \
+  git clone \
+    --branch v${RIST} \
+    --depth 1 https://code.videolan.org/rist/librist.git \
+    /tmp/rist
+RUN \
+  echo "**** compiling rist ****" && \
+  cd /tmp/rist && \
+  mkdir -p \
+    rist_build && \
+  cd rist_build && \
+  meson \
+    --default-library=shared .. && \
+  ninja && \
+  ninja install
+RUN \
+  echo "**** grabbing srt ****" && \
+  mkdir -p /tmp/srt && \
+  git clone \
+    --branch v${SRT} \
+    --depth 1 https://github.com/Haivision/srt.git \
+    /tmp/srt
+RUN \
+  echo "**** compiling srt ****" && \
+  cd /tmp/srt && \
+  mkdir -p \
+    srt_build && \
+  cd srt_build && \
+  cmake \
+    -DBUILD_SHARED_LIBS:BOOL=on .. && \
+  make && \
+  make install
+RUN \
   echo "**** compiling SVT-AV1 ****" && \
   cd /tmp/svt-av1/Build && \
   cmake .. -G"Unix Makefiles" -DCMAKE_BUILD_TYPE=Release && \
@@ -530,6 +566,8 @@ RUN \
     --enable-libopenjpeg \
     --enable-libopus \
     --enable-librav1e \
+    --enable-librist \
+    --enable-libsrt \
     --enable-libsvtav1 \
     --enable-libtheora \
     --enable-libv4l2 \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -336,12 +336,6 @@ RUN \
   cargo cinstall --release && \
   strip -d /usr/local/lib/librav1e.so
 RUN \
-  echo "**** grabbing SVT-AV1 ****" && \
-  mkdir -p /tmp/svt-av1 && \
-  curl -Lf \
-    https://gitlab.com/AOMediaCodec/SVT-AV1/-/archive/v${SVTAV1}/SVT-AV1-v${SVTAV1}.tar.gz | \
-    tar -zx --strip-components=1 -C /tmp/svt-av1
-RUN \
   echo "**** grabbing rist ****" && \
   mkdir -p /tmp/rist && \
   git clone \
@@ -375,6 +369,12 @@ RUN \
     -DBUILD_SHARED_LIBS:BOOL=on .. && \
   make && \
   make install
+RUN \
+  echo "**** grabbing SVT-AV1 ****" && \
+  mkdir -p /tmp/svt-av1 && \
+  curl -Lf \
+    https://gitlab.com/AOMediaCodec/SVT-AV1/-/archive/v${SVTAV1}/SVT-AV1-v${SVTAV1}.tar.gz | \
+    tar -zx --strip-components=1 -C /tmp/svt-av1
 RUN \
   echo "**** compiling SVT-AV1 ****" && \
   cd /tmp/svt-av1/Build && \

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -178,6 +178,7 @@ full_custom_readme: |
 
   ## Versions
 
+  * **14.08.24:** - Add SRT and libRIST.
   * **01.08.24:** - Add libdav1d. Bump libharfbuzz, various Intel drivers and libs, libass, libdrm, libplacebo, libva, mesa, svtav1, and vulkan sdk.
   * **21.06.24:** - Bump mesa and libaom. Update lib path for rav1e.
   * **08.06.24:** - Bump ffmpeg, fribidi, libdrm, mesa and vpx.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-ffmpeg/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
<!--- Describe your changes in detail -->
Added support for the SRT protocol by pulling the latest tag from Haivision's GitHub repository and building it with shared libraries enabled using CMake & Make.
Added support for the RIST protocol by pulling the latest tag from VideoLAN's GitLab repository and building it with shared libraries enabled using Meson & Ninja.

I did not include the changes in the Dockerfile.aarch64 as I currently do not have any way of testing this architecture but to extend the functionality to it should probably be just a question of copying and pasting the code into the file.

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->
This extends the capabilities of the FFMPEG tool provided in this container image by allowing the user to stream in and out using the added modern video streaming protocols.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Checked that no build error occurred when creating the image from the Dockerfile
2. Checked that the protocols were available for both input and output with the "-protocols" command line option
3. Did a quick streaming test to show that FFMPEG in the container is able to stream a video using the protocols to FFPLAY on the host computer

## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
https://github.com/Haivision/srt
https://code.videolan.org/rist/librist