### PR TITLE
Add libzmq for ZMQ support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,7 +57,8 @@ ENV \
   WEBP=1.4.0 \
   X265=3.6 \
   XVID=1.3.7 \
-  ZIMG=3.0.5
+  ZIMG=3.0.5 \
+  ZMQ=v4.3.5
 
 RUN \
   echo "**** install build packages ****" && \
@@ -459,7 +460,7 @@ RUN \
   echo "**** compiling libvpl ****" && \
   mkdir -p /tmp/libvpl/build && \
   cd /tmp/libvpl/build && \
-  cmake .. && \ 
+  cmake .. && \
   cmake --build . --config Release && \
   cmake --build . --config Release --target install && \
   strip -d /usr/local/lib/libvpl.so
@@ -476,7 +477,7 @@ RUN \
   cmake \
     -DCMAKE_INSTALL_PREFIX=/usr \
     -DCMAKE_INSTALL_LIBDIR=/usr/local/lib \
-    .. && \ 
+    .. && \
   make && \
   make install && \
   strip -d /usr/local/lib/libmfx-gen.so
@@ -497,7 +498,7 @@ RUN \
     -DENABLE_X11_DRI3=ON \
     -DBUILD_DISPATCHER=OFF \
     -DBUILD_TUTORIALS=OFF \
-    .. && \ 
+    .. && \
   make && \
   make install && \
   strip -d \
@@ -820,7 +821,7 @@ RUN \
 RUN \
   echo "**** compiling xvid ****" && \
   cd /tmp/xvid/build/generic && \
-  ./configure && \ 
+  ./configure && \
   make && \
   make install
 RUN \
@@ -839,6 +840,22 @@ RUN \
     --enable-shared && \
   make && \
   make install
+RUN \
+  echo "**** grabbing zmq ****" && \
+  mkdir -p /tmp/zmq && \
+  git clone \
+    --branch ${ZMQ} --depth 1 \
+    https://github.com/zeromq/libzmq.git \
+    /tmp/zmq
+RUN \
+  echo "**** compiling zmq ****" && \
+  cd /tmp/zmq && \
+  ./autogen.sh && \
+  ./configure \
+    --disable-static \
+    --enable-shared && \
+  make && \
+  make install-strip
 
 # main ffmpeg build
 RUN \
@@ -899,6 +916,7 @@ RUN \
     --enable-libxml2 \
     --enable-libxvid \
     --enable-libzimg \
+    --enable-libzmq \
     --enable-nonfree \
     --enable-nvdec \
     --enable-nvenc \
@@ -908,7 +926,8 @@ RUN \
     --enable-vaapi \
     --enable-vdpau \
     --enable-version3 \
-    --enable-vulkan && \
+    --enable-vulkan \
+    && \
   make
 
 RUN \
@@ -1031,4 +1050,3 @@ RUN \
 COPY /root /
 
 ENTRYPOINT ["/ffmpegwrapper.sh"]
-

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -37,7 +37,7 @@ ENV \
   OPUS=1.5.2 \
   RAV1E=0.7.1 \
   RIST=0.2.10 \
-  SRT=1.5.3 \  
+  SRT=1.5.3 \
   SVTAV1=2.2.1 \
   THEORA=1.1.1 \
   VORBIS=1.3.7 \
@@ -45,11 +45,12 @@ ENV \
   WEBP=1.4.0 \
   X265=3.6 \
   XVID=1.3.7 \
-  ZIMG=3.0.5
+  ZIMG=3.0.5 \
+  ZMQ=v4.3.5
 
 RUN \
   echo "**** install build packages ****" && \
-  apt-get update && \ 
+  apt-get update && \
   apt-get install -y \
     autoconf \
     automake \
@@ -536,7 +537,7 @@ RUN \
 RUN \
   echo "**** compiling xvid ****" && \
   cd /tmp/xvid/build/generic && \
-  ./configure && \ 
+  ./configure && \
   make && \
   make install
 RUN \
@@ -555,6 +556,22 @@ RUN \
     --enable-shared && \
   make && \
   make install
+RUN \
+  echo "**** grabbing zmq ****" && \
+  mkdir -p /tmp/zmq && \
+  git clone \
+    --branch ${ZMQ} --depth 1 \
+    https://github.com/zeromq/libzmq.git \
+    /tmp/zmq
+RUN \
+  echo "**** compiling zmq ****" && \
+  cd /tmp/zmq && \
+  ./autogen.sh && \
+  ./configure \
+    --disable-static \
+    --enable-shared && \
+  make && \
+  make install-strip
 
 # main ffmpeg build
 RUN \
@@ -608,17 +625,19 @@ RUN \
     --enable-libvorbis \
     --enable-libvpx \
     --enable-libwebp \
-    --enable-libxml2 \
     --enable-libx264 \
     --enable-libx265 \
+    --enable-libxml2 \
     --enable-libxvid \
     --enable-libzimg \
+    --enable-libzmq \
     --enable-nonfree \
     --enable-nvdec \
     --enable-nvenc \
     --enable-openssl \
     --enable-stripping \
-    --enable-version3 && \
+    --enable-version3 \
+    && \
   make
 
 RUN \

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -178,6 +178,7 @@ full_custom_readme: |
 
   ## Versions
 
+  * **09.09.24:** - Add libzmq.
   * **31.08.24:** - Bump libaom, libdrm, libvpl, mesa and svtav1. Enable nvdec/nvenc on arm64 (untested).
   * **17.08.24:** - Bump ffmpeg, freetype, libdovi and mesa.
   * **14.08.24:** - Add SRT and libRIST.


### PR DESCRIPTION
## How Has This Been Tested?

`docker buildx build -t linuxserver/ffmpeg .` and then `docker run --rm -it linuxserver/ffmpeg -protocols` and confirming zmq is listed.


 - [ x] I have read the [contributing](https://github.com/linuxserver/docker-ffmpeg/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

## Description:

Add libzmq to build process and enable zmq protocol.

## Benefits of this PR and context:

ZMQ is not a widely used protocol for ffmpeg but is useful for building certain patterns.

## How Has This Been Tested?

Confirmed the build functions. Ran `-protocols` and confirmed it shows up.

Unfortunately, at the moment the ZMQ protocol is broken in the latest ffmpeg but should be fixed in the next release.

https://patchwork.ffmpeg.org/project/ffmpeg/patch/20240826210808.19594-1-cus@passwd.hu/
